### PR TITLE
fix: don't call super, but the origin devise's method

### DIFF
--- a/lib/decidim/extends/controllers/confirmations_controller_extend.rb
+++ b/lib/decidim/extends/controllers/confirmations_controller_extend.rb
@@ -13,7 +13,7 @@ module ConfirmationsControllerExtend
       if first_login_and_not_authorized?(resource)
         decidim_verifications.new_authorization_path(action: :new, handler: :socio_demographic_authorization_handler)
       else
-        super
+        signed_in_root_path(resource)
       end
     end
 


### PR DESCRIPTION
[as the original method](https://github.com/heartcombo/devise/blob/025b1c873491908b346e4d394f54481ec18fb02c/app/controllers/devise/confirmations_controller.rb#L42) will be overriden, we can't call super. 
Let's call the `signed_in_root_path` as user is always signed in in our case. (see [`sign_in(resource) unless user_signed_in?`](https://github.com/octree-gva/decidim-module-socio_demographic_authorization_handler/blob/5e8ee0b8295c3be2d305118aaf7801f201adeed9/lib/decidim/extends/controllers/confirmations_controller_extend.rb#L11))

fix #1